### PR TITLE
Jbarno/travis playground - Re-enable karma tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ services:
 - docker
 jobs:
   include:
+  - stage: test
+    script:
+    - npm run test
   - stage: deploy
     script:
     - npm run build
     - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       quay.io
     - bash docker.sh
-  - stage: test
-    script:
-    - npm run test
 notifications:
   slack:
     secure: Njn9VjYMUJcb8jfvusetb13uC0rcQ1NN6KumKxc6/jBCRoQ7uhQbqhcemZDK/7s/jRUGYTkb72u5QJxgVHcYDMchO9aOCVI3xs8veQ6j6shOCJbSIHGby1nkuwDPNzyyYh5mjJVDiWbiIBOzOaMko0QT//Ce1IitBBkyTEtQPcg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ jobs:
     - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       quay.io
     - bash docker.sh
+  - stage: test
+    script:
+    - npm run test
 notifications:
   slack:
     secure: Njn9VjYMUJcb8jfvusetb13uC0rcQ1NN6KumKxc6/jBCRoQ7uhQbqhcemZDK/7s/jRUGYTkb72u5QJxgVHcYDMchO9aOCVI3xs8veQ6j6shOCJbSIHGby1nkuwDPNzyyYh5mjJVDiWbiIBOzOaMko0QT//Ce1IitBBkyTEtQPcg=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Setup Successful!
 #### Remote API & ElasticSearch, Local UI
 Connect to VPN and run ui with
 ```
-GDC_API=https://portal.gdc.cancer.gov/auth/api/v0 GDC_FAKE_AUTH=true npm start
+GDC_API=https://api.gdc.cancer.gov/v0/legacy GDC_FAKE_AUTH=true npm start
 ```
 
 #### Local API, Remote ElastiSearch and Local UI
@@ -72,11 +72,8 @@ Not recommended, would require loading local ES with data.
 
 ### Authentication
 In order to properly run the UI and login to test the auth you will need to run the application
-in a specific way. This includes `sudo` and running the app on port `80`. You will need to ensure
-that you don't have something else using that port (like a local apache setup).
-
-The following command should work:
-`sudo GDC_API=http://portal.gdc.cancer.gov:5000 GDC_PORT=80 npm start`
+in a specific way. Locally, auth can be faked with GDC_FAKE_AUTH=true npm start.
+To really test auth please vpn into an environment.
 
 #### Modifying /etc/hosts
 In order to support local use of the login system we need to add the following

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/NCI-GDC/portal-ui-legacy.svg?branch=next)](https://travis-ci.org/NCI-GDC/portal-ui-legacy)
+
 `Buzzwords: #typescript #angularjs #gulp #less #bower #karma`
 
 - [Technologies](#technologies)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Setup Successful!
 #### Remote API & ElasticSearch, Local UI
 Connect to VPN and run ui with
 ```
-GDC_API=https://gdc-portal.nci.nih.gov/auth/api/v0 GDC_FAKE_AUTH=true npm start
+GDC_API=https://portal.gdc.cancer.gov/auth/api/v0 GDC_FAKE_AUTH=true npm start
 ```
 
 #### Local API, Remote ElastiSearch and Local UI
@@ -74,13 +74,13 @@ in a specific way. This includes `sudo` and running the app on port `80`. You wi
 that you don't have something else using that port (like a local apache setup).
 
 The following command should work:
-`sudo GDC_API=http://portal.gdc.nci.nih.gov:5000 GDC_PORT=80 npm start`
+`sudo GDC_API=http://portal.gdc.cancer.gov:5000 GDC_PORT=80 npm start`
 
 #### Modifying /etc/hosts
 In order to support local use of the login system we need to add the following
 to your `/etc/hosts` file:
 
-`127.0.0.1 gdc-portal.nci.nih.gov`
+`127.0.0.1 portal.gdc.cancer.gov`
 
 ### ElasticSearch
 If you are connecting to a local ES, edit path-to-elastic-search/config/elasticsearch.yml, find the line with http.max_content_length, add
@@ -136,11 +136,11 @@ Using ChromeDriver directly...
 The development server is setup using Browsersync
 
 ```
-❯ GDC_API="http://gdc-portal.nci.nih.gov:5000" npm start
+❯ GDC_API="http://portal.gdc.cancer.gov:5000" npm start
 [16:47:02] Environment Development
 ...
 [BS] Local URL: http://localhost:3000
-[BS] External URL: http://gdc-portal.nci.nih.gov:3000
+[BS] External URL: http://portal.gdc.cancer.gov:3000
 [BS] Serving files from: dist
 ```
 


### PR DESCRIPTION
Accidentally started this off of the master branch instead of next. Rebased onto next and that's why there's the double person commits. Can change if you guys want but it all looks good to me.

- Add a test stage after deploy, tests weren't being run on Travis (they're all good)
- Removed the nci.nih urls from the README.md for portal.gdc.cancer
- Added a travis badge (pointed to **next**), which I think is the right branch.


I'm playing around with protractor now, but I think it is using some old automation plugin that google chrome nixed a while back, so no promises. 